### PR TITLE
Add option to round targetPosition for WindowCovering.

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,8 @@ topic
 payload
 
 * targetPositionFactor (default: `1`)
-* currentPositionFactor (default: `1`)
+* currentPositionFactor (default: `1`) 
+* roundTarget (boolean)
 * positionStatusIncreasing
 * positionStatusDecreasing
 * identify (optional)

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ payload
 
 * targetPositionFactor (default: `1`)
 * currentPositionFactor (default: `1`) 
-* roundTarget (boolean)
+* roundTarget (boolean, optional)
 * positionStatusIncreasing
 * positionStatusDecreasing
 * identify (optional)

--- a/index.js
+++ b/index.js
@@ -839,7 +839,6 @@ var createAccessory = {
     WindowCovering: function createAccessory_WindowCovering(settings) {
         var shutter = newAccessory(settings);
 
-        
         shutter.addService(Service.WindowCovering, settings.name)
             .getCharacteristic(Characteristic.TargetPosition)
             .on('set', function (value, callback) {
@@ -918,7 +917,6 @@ var createAccessory = {
 
                 });
         }
-        
 
         return shutter;
 

--- a/index.js
+++ b/index.js
@@ -844,6 +844,9 @@ var createAccessory = {
             .on('set', function (value, callback) {
                 log.debug('< hap set', settings.name, 'TargetPosition', value);
                 value = (value * (settings.payload.targetPositionFactor || 1));
+                if (setting.payload.roundTarget === true) {
+                    value = Math.round(value);
+                }
                 log.debug('> mqtt', settings.topic.setTargetPosition, value);
                 mqttPub(settings.topic.setTargetPosition, value);
                 callback();

--- a/index.js
+++ b/index.js
@@ -839,12 +839,13 @@ var createAccessory = {
     WindowCovering: function createAccessory_WindowCovering(settings) {
         var shutter = newAccessory(settings);
 
+        
         shutter.addService(Service.WindowCovering, settings.name)
             .getCharacteristic(Characteristic.TargetPosition)
             .on('set', function (value, callback) {
                 log.debug('< hap set', settings.name, 'TargetPosition', value);
                 value = (value * (settings.payload.targetPositionFactor || 1));
-                if (setting.payload.roundTarget === true) {
+                if (settings.payload.roundTarget === true) {
                     value = Math.round(value);
                 }
                 log.debug('> mqtt', settings.topic.setTargetPosition, value);
@@ -917,6 +918,7 @@ var createAccessory = {
 
                 });
         }
+        
 
         return shutter;
 


### PR DESCRIPTION
Because of the `targetPositionFactor`, the new target position can be a float. Since not all systems allow floats, I've added an option to round the target values. By setting `settings.payload.roundTarget ` to `true` the new target position will be rounded.