### PR TITLE
Thermostat accessory improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 .DS_Store
+persist

--- a/accessories/TemperatureSensor.js
+++ b/accessories/TemperatureSensor.js
@@ -14,7 +14,7 @@ module.exports = function (iface) {
 
         sensor.addService(Service.TemperatureSensor)
             .getCharacteristic(Characteristic.CurrentTemperature)
-            .setProps({minValue: -100})
+            .setProps((settings.props || {}).CurrentTemperature || {minValue: -100})
             .on('get', callback => {
                 log.debug('< hap get', settings.name, 'TemperatureSensor', 'CurrentTemperature');
                 log.debug('> hap re_get', settings.name, mqttStatus[settings.topic.statusTemperature]);

--- a/accessories/TemperatureSensor.js
+++ b/accessories/TemperatureSensor.js
@@ -9,7 +9,7 @@ module.exports = function (iface) {
         mqttSub(settings.topic.statusTemperature, val => {
             log.debug('> hap set', settings.name, 'CurrentTemperature', mqttStatus[settings.topic.statusTemperature]);
             sensor.getService(Service.TemperatureSensor)
-                .setCharacteristic(Characteristic.CurrentTemperature, val);
+                .updateCharacteristic(Characteristic.CurrentTemperature, val);
         });
 
         sensor.addService(Service.TemperatureSensor)

--- a/accessories/Thermostat.js
+++ b/accessories/Thermostat.js
@@ -11,6 +11,10 @@ module.exports = function (iface) {
             .on('set', (value, callback) => {
                 log.debug('< hap set', settings.name, 'TargetHeatingCoolingState', value);
                 if (settings.topic.setTargetHeatingCoolingState) {
+                    if (settings.payload && settings.payload.TargetHeatingCoolingState &&
+                        settings.payload.TargetHeatingCoolingState[String(value)] !== undefined) {
+                        value = settings.payload.TargetHeatingCoolingState[value];
+                    }
                     log.debug('> mqtt', settings.topic.setTargetHeatingCoolingState, value);
                     mqttPub(settings.topic.setTargetHeatingCoolingState, value);
                 }

--- a/accessories/Thermostat.js
+++ b/accessories/Thermostat.js
@@ -16,7 +16,7 @@ module.exports = function (iface) {
                         value = settings.payload.TargetHeatingCoolingState[value];
                     }
                     log.debug('> mqtt', settings.topic.setTargetHeatingCoolingState, value);
-                    mqttPub(settings.topic.setTargetHeatingCoolingState, value);
+                    mqttPub(settings.topic.setTargetHeatingCoolingState, value, settings.mqttPublishOptions);
                 }
                 callback();
             });
@@ -26,7 +26,7 @@ module.exports = function (iface) {
             .on('set', (value, callback) => {
                 log.debug('< hap set', settings.name, 'TargetTemperature', value);
                 log.debug('> mqtt', settings.topic.setTargetTemperature, value);
-                mqttPub(settings.topic.setTargetTemperature, value);
+                mqttPub(settings.topic.setTargetTemperature, value, settings.mqttPublishOptions);
                 callback();
             });
 

--- a/accessories/Thermostat.js
+++ b/accessories/Thermostat.js
@@ -50,6 +50,7 @@ module.exports = function (iface) {
         });
         thermo.getService(Service.Thermostat)
             .getCharacteristic(Characteristic.CurrentTemperature)
+            .setProps((settings.props || {}).CurrentTemperature || {})
             .on('get', callback => {
                 log.debug('< hap get', settings.name, 'CurrentTemperature');
                 log.debug('> hap re_get', settings.name, 'CurrentTemperature', mqttStatus[settings.topic.statusCurrentTemperature]);
@@ -73,6 +74,7 @@ module.exports = function (iface) {
 
         thermo.getService(Service.Thermostat)
             .getCharacteristic(Characteristic.TargetTemperature)
+            .setProps((settings.props || {}).TargetTemperature || {})
             .on('get', callback => {
                 log.debug('< hap get', settings.name, 'TargetTemperature');
                 log.debug('> hap re_get', settings.name, 'TargetTemperature', mqttStatus[settings.topic.statusTargetTemperature]);

--- a/accessories/Thermostat.js
+++ b/accessories/Thermostat.js
@@ -50,7 +50,7 @@ module.exports = function (iface) {
         mqttSub(settings.topic.statusCurrentTemperature, function (val) {
             log.debug('> hap set', settings.name, 'CurrentTemperature', mqttStatus[settings.topic.statusCurrentTemperature]);
             thermo.getService(Service.Thermostat)
-                .setCharacteristic(Characteristic.CurrentTemperature, val);
+                .updateCharacteristic(Characteristic.CurrentTemperature, val);
         });
         thermo.getService(Service.Thermostat)
             .getCharacteristic(Characteristic.CurrentTemperature)
@@ -63,8 +63,9 @@ module.exports = function (iface) {
 
         if (settings.topic.statusCurrentHeatingCoolingState) {
             mqttSub(settings.topic.statusCurrentHeatingCoolingState, val => {
+                log.debug('> hap set', settings.name, 'CurrentHeatingCoolingState', val);
                 thermo.getService(Service.Thermostat)
-                    .setCharacteristic(Characteristic.CurrentHeatingCoolingState, val);
+                    .updateCharacteristic(Characteristic.CurrentHeatingCoolingState, val);
             });
             thermo.getService(Service.Thermostat)
                 .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
@@ -93,7 +94,7 @@ module.exports = function (iface) {
         if (settings.topic.statusCurrentRelativeHumidity) {
             mqttSub(settings.topic.statusCurrentRelativeHumidity, val => {
                 thermo.getService(Service.Thermostat)
-                    .setCharacteristic(Characteristic.CurrentRelativeHumidity, val);
+                    .updateCharacteristic(Characteristic.CurrentRelativeHumidity, val);
             });
             thermo.getService(Service.Thermostat)
                 .getCharacteristic(Characteristic.CurrentRelativeHumidity)

--- a/accessories/Thermostat.js
+++ b/accessories/Thermostat.js
@@ -61,14 +61,19 @@ module.exports = function (iface) {
                 callback(null, mqttStatus[settings.topic.statusCurrentTemperature]);
             });
 
-        thermo.getService(Service.Thermostat)
-            .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-            .on('get', callback => {
-                log.debug('< hap get', settings.name, 'CurrentHeatingCoolingState');
-                const state = 1; // HEATING
-                log.debug('> hap re_get', settings.name, 'CurrentHeatingCoolingState', state);
-                callback(null, state);
+        if (settings.topic.statusCurrentHeatingCoolingState) {
+            mqttSub(settings.topic.statusCurrentHeatingCoolingState, val => {
+                thermo.getService(Service.Thermostat)
+                    .setCharacteristic(Characteristic.CurrentHeatingCoolingState, val);
             });
+            thermo.getService(Service.Thermostat)
+                .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+                .on('get', callback => {
+                    log.debug('< hap get', settings.name, 'CurrentHeatingCoolingState');
+                    log.debug('> hap re_get', settings.name, 'CurrentHeatingCoolingState', mqttStatus[settings.topic.statusCurrentHeatingCoolingState]);
+                    callback(null, mqttStatus[settings.topic.statusCurrentHeatingCoolingState]);
+                });
+        }
 
         mqttSub(settings.topic.statusTargetTemperature, val => {
             log.debug('> hap set', settings.name, 'TargetTemperature', val);

--- a/accessories/Thermostat.js
+++ b/accessories/Thermostat.js
@@ -43,7 +43,11 @@ module.exports = function (iface) {
                 callback(null, settings.config.TemperatureDisplayUnits);
             });
 
-        mqttSub(settings.topic.statusCurrentTemperature);
+        mqttSub(settings.topic.statusCurrentTemperature, function (val) {
+            log.debug('> hap set', settings.name, 'CurrentTemperature', mqttStatus[settings.topic.statusCurrentTemperature]);
+            thermo.getService(Service.Thermostat)
+                .setCharacteristic(Characteristic.CurrentTemperature, val);
+        });
         thermo.getService(Service.Thermostat)
             .getCharacteristic(Characteristic.CurrentTemperature)
             .on('get', callback => {
@@ -61,12 +65,11 @@ module.exports = function (iface) {
                 callback(null, state);
             });
 
-        // Thermo.getService(Service.Thermostat).setCharacteristic(Characteristic.CurrentHeatingCoolingState, 3);
-
-        mqttSub(settings.topic.statusTargetTemperature/* , function (val) {
-         thermo.getService(Service.Thermostat)
-         .setCharacteristic(Characteristic.TargetTemperature, val);
-         } */);
+        mqttSub(settings.topic.statusTargetTemperature, val => {
+            log.debug('> hap set', settings.name, 'TargetTemperature', val);
+            thermo.getService(Service.Thermostat)
+                .updateCharacteristic(Characteristic.TargetTemperature, val);
+        });
 
         thermo.getService(Service.Thermostat)
             .getCharacteristic(Characteristic.TargetTemperature)


### PR DESCRIPTION
This PR adds a few small improvements to the `Thermostat` accessory, namely:

 - Improve sync between MQTT messages and HomeKit values:
   - Update Thermostat Current/TargetTemperature from MQTT
   - Set Thermostat.CurrentHeatingCoolingState from MQTT
 - Provide more control over Thermostat options from mapping file:
   - Set Thermostat/CurrentTemperature properties from mapping file
   - Thermostat payload can be controlled from mapping
   - Use MQTT publish options from mapping, e.g. for retained messages
 - Use updateCharacteristic instead of setCharacteristic when updating homekit values from MQTT topics
 - Ignore persist directory
