### PR TITLE
load file of module without own path logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const app = express();
 
 const log = require('yalm');
 const HAP = require('hap-nodejs');
-const pkgHap = require('./node_modules/hap-nodejs/package.json');
+const pkgHap = require('hap-nodejs/package.json');
 const pkg = require('./package.json');
 const config = require('./config.js');
 


### PR DESCRIPTION
Starting with ./ the node.js logic of finding the module does not work
anymore. the specific file has to be at the exact path instead just
below the package found by node.js.

Reference (last sentence of "Loading from node_modules Folders"):
https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders

I use homekit2mqtt as a package inside an own package as a dependency. In order to get it running on a raspberry I just have to clone my own repository, `npm i` and `npm start` as i include the config.json and so on with the repo. Everything is at one place and can easily backed up or moved to another device.

The current logic works with the globally installed package as it tries to get to the node_module folder below. As a package dependency the hap-nodejs module is installed besides homekit2mqtt. As a relative path `../hap-nodejs/package.json` would be needed.
These relative paths can be avoided by using the node.js build in package finder.