### PR TITLE
allow loading of relative config paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ function createBridge() {
 
     // Load and create all accessories
     log.info('loading HomeKit to MQTT mapping file ' + config.mapfile);
-    mapping = require(config.mapfile);
+    mapping = JSON.parse(fs.readFileSync(config.mapfile));
     convertMapping();
     accCount = 0;
     Object.keys(mapping).forEach(id => {


### PR DESCRIPTION
Currently it is not possible to load the config from a relative directory.

For example using `… -m config.json …` the searched paths contain the working directory which works fine (but many node_modules folders will get searched unnecessary).
When using `… -m ./config.json …` (or something else relative) only paths relative to the global install point will be used (`/usr/lib/node_modules/homekit2mqtt/config.json`)

The exact paths that will be tried can be found out with [`require.resolve.paths`](https://nodejs.org/api/modules.html#modules_require_resolve_paths_request).

Saving the config is already done with the fs API. Was there a reason to use require instead of JSON.parse and the fs API?