### PR TITLE
Option to retain MQTT messages

### DIFF
--- a/config.js
+++ b/config.js
@@ -13,6 +13,8 @@ const config = require('yargs')
     .boolean('disable-json-parse')
     .describe('insecure', 'allow tls connections with invalid certificates')
     .boolean('insecure')
+    .describe('retain', 'if set, ALL MQTT messages sent will have the retain flag set')
+    .boolean('retain')
     .describe('h', 'show help')
     .alias({
         h: 'help',

--- a/index.js
+++ b/index.js
@@ -129,6 +129,12 @@ function mqttPub(topic, payload, options) {
             payload = String(payload);
         }
         log.debug('> mqtt', topic, payload);
+        if (config.retain) {
+            if (!options) {
+                options = {};
+            }
+            options.retain = true;
+        }
         mqtt.publish(topic, payload, options, err => {
             /* istanbul ignore next */
             if (err) {


### PR DESCRIPTION
Provides a new command line argument to allow all MQTT messages to be sent with the retain flag set.

Fixes #103 