### PR TITLE
fix webgui load node_modules from all possible paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -477,8 +477,11 @@ if (config.disableWeb) {
         res.redirect(301, '/ui');
     });
     app.use('/ui', express.static(path.join(__dirname, '/ui')));
-    app.use('/node_modules', express.static(path.join(__dirname, '/node_modules')));
     app.use('/services.json', express.static(path.join(__dirname, '/services.json')));
+
+    module.paths.forEach(folder => {
+        app.use('/node_modules', express.static(folder));
+    });
 
     app.get('/topics', (req, res) => {
         log.info('http > topics');


### PR DESCRIPTION
As npm can install dependancies on multiple directories they should be loaded from all of them. `express.static` will use the first successful hit.

I use homekit2mqtt as a package inside an own package as a dependency. In order to get it running on a raspberry I just have to clone my own repository, `npm i` and `npm start` as i include the config.json and so on with the repo. Everything is at one place and can easily backed up or moved to another device.

The current logic works with the globally installed package as it tries to get to the node_module folder below. As a package dependency the dependancies of homekit2mqtt can be installed on multiple locations depending on the version of npm.

Finding out the paths where a module can be installed is possible with [`module.paths`](https://nodejs.org/api/modules.html#modules_module_paths). There is also [`require.resolve.paths`](https://nodejs.org/api/modules.html#modules_require_resolve_paths_request) which returns more possible folders but requires node v8.9 (currently node>=6.0.0 is required by the package.json).

I assumed this would also search for globally installed node_modules but is not the case.

This code was tested on macOS and Arch Linux:
```js
console.log('__dirname', __dirname)
console.log('module.paths', module.paths)
console.log('require.resolve.paths(\'express\')', require.resolve.paths('express'))
```

macOS Result (global location: `/usr/local/lib/node_modules`)
```js
__dirname /Users/edjopato/git/home/etoHomebridge/node_modules/homekit2mqtt
module.paths [
  '/Users/edjopato/git/home/etoHomebridge/node_modules/homekit2mqtt/node_modules',
  '/Users/edjopato/git/home/etoHomebridge/node_modules',
  '/Users/edjopato/git/home/node_modules',
  '/Users/edjopato/git/node_modules',
  '/Users/edjopato/node_modules',
  '/Users/node_modules',
  '/node_modules' ]
require.resolve.paths('express') [
  '/Users/edjopato/git/home/etoHomebridge/node_modules/homekit2mqtt/node_modules',
  '/Users/edjopato/git/home/etoHomebridge/node_modules',
  '/Users/edjopato/git/home/node_modules',
  '/Users/edjopato/git/node_modules',
  '/Users/edjopato/node_modules',
  '/Users/node_modules',
  '/node_modules',
  '/Users/edjopato/.node_modules',
  '/Users/edjopato/.node_libraries',
  '/usr/local/Cellar/node/10.9.0/lib/node' ]
```

Arch Linux Result (global location: `/usr/lib/node_modules`).
```js
__dirname /home/edjopato/Documents/tmp
module.paths [
  '/home/edjopato/Documents/tmp/node_modules',
  '/home/edjopato/Documents/node_modules',
  '/home/edjopato/node_modules',
  '/home/node_modules',
  '/node_modules' ]
require.resolve.paths('express') [
  '/home/edjopato/Documents/tmp/node_modules',
  '/home/edjopato/Documents/node_modules',
  '/home/edjopato/node_modules',
  '/home/node_modules',
  '/node_modules',
  '/home/edjopato/.node_modules',
  '/home/edjopato/.node_libraries',
  '/usr/lib/node' ]
```
